### PR TITLE
Match require('buffer') exactly

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It's a drop-in replacement for `Buffer`. You can use it by adding one `require` 
 the top of your node.js modules:
 
 ```js
-var Buffer = require('safe-buffer')
+var Buffer = require('safe-buffer').Buffer
 
 // Existing buffer code will continue to work without issues:
 
@@ -545,7 +545,7 @@ Fortunately, there's an easy fix that can be applied today. Use `safe-buffer` in
 `buffer`.
 
 ```js
-var Buffer = require('safe-buffer')
+var Buffer = require('safe-buffer').Buffer
 ```
 
 Eventually, we hope that node.js core can switch to this new, safer behavior. We believe

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,1 @@
+module.exports = require('buffer')

--- a/index.js
+++ b/index.js
@@ -1,59 +1,58 @@
-module.exports = SafeBuffer
-module.exports.Buffer = SafeBuffer
+var buffer = require('buffer')
 
-var SlowBuffer = require('buffer').SlowBuffer
+if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
+  module.exports = buffer
+} else {
+  // Copy properties from require('buffer')
+  Object.keys(buffer).forEach(function (prop) {
+    exports[prop] = buffer[prop]
+  })
+  exports.Buffer = SafeBuffer
+}
 
 function SafeBuffer (arg, encodingOrOffset, length) {
   return Buffer(arg, encodingOrOffset, length)
 }
 
-// Copy static functions
+// Copy static methods from Buffer
 Object.keys(Buffer).forEach(function (prop) {
   SafeBuffer[prop] = Buffer[prop]
 })
 
-if (!SafeBuffer.from) {
-  SafeBuffer.from = function (arg, encodingOrOffset, length) {
-    if (typeof value === 'number') {
-      throw new TypeError('Argument must not be a number')
-    }
-    return Buffer(arg, encodingOrOffset, length)
+SafeBuffer.from = function (arg, encodingOrOffset, length) {
+  if (typeof value === 'number') {
+    throw new TypeError('Argument must not be a number')
   }
+  return Buffer(arg, encodingOrOffset, length)
 }
 
-if (!SafeBuffer.alloc) {
-  SafeBuffer.alloc = function (size, fill, encoding) {
-    if (typeof size !== 'number') {
-      throw new TypeError('Argument must be a number')
-    }
-    var buf = Buffer(size)
-    if (fill !== undefined) {
-      if (typeof encoding === 'string') {
-        buf.fill(fill, encoding)
-      } else {
-        buf.fill(fill)
-      }
+SafeBuffer.alloc = function (size, fill, encoding) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
+  }
+  var buf = Buffer(size)
+  if (fill !== undefined) {
+    if (typeof encoding === 'string') {
+      buf.fill(fill, encoding)
     } else {
-      buf.fill(0)
+      buf.fill(fill)
     }
-    return buf
+  } else {
+    buf.fill(0)
   }
+  return buf
 }
 
-if (!SafeBuffer.allocUnsafe) {
-  SafeBuffer.allocUnsafe = function (size) {
-    if (typeof size !== 'number') {
-      throw new TypeError('Argument must be a number')
-    }
-    return Buffer(size)
+SafeBuffer.allocUnsafe = function (size) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
   }
+  return Buffer(size)
 }
 
-if (!SafeBuffer.allocUnsafeSlow) {
-  SafeBuffer.allocUnsafeSlow = function (size) {
-    if (typeof size !== 'number') {
-      throw new TypeError('Argument must be a number')
-    }
-    return SlowBuffer(size)
+SafeBuffer.allocUnsafeSlow = function (size) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
   }
+  return buffer.SlowBuffer(size)
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/feross/safe-buffer/issues"
   },
-  "dependencies": {},
+  "browser": "./browser.js",
   "devDependencies": {
     "standard": "^7.0.0",
     "tape": "^4.0.0",


### PR DESCRIPTION
- Copy all the properties from require('buffer') onto
require('safe-buffer')

- Don't export Buffer at require('safe-buffer'). User should do
require('safe-buffer').Buffer instead, to match Node.js API.

- Do nothing in Node v6 or in the browser, since the browserify shim
already has support for all the new APIs.