### PR TITLE
Add .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+.travis.yml
+test.js


### PR DESCRIPTION
Ingore `test.js` and `.travis.yml` if you install `safe-buffer` with NPM.

> The following paths and files are never ignored, so adding them to .npmignore is pointless:
> 
> package.json
> README (and its variants)
> CHANGELOG (and its variants)
> LICENSE / LICENCE

https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package