### PR TITLE
No browser version

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,1 +1,0 @@
-module.exports = require('buffer')

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-buffer-constructor */
 var buffer = require('buffer')
 
 if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "bugs": {
     "url": "https://github.com/feross/safe-buffer/issues"
   },
-  "browser": "./browser.js",
   "devDependencies": {
     "standard": "*",
     "tape": "^4.0.0",


### PR DESCRIPTION
this improves on #11 and #10 by simply removing the browser version, this avoids bringing in a second buffer dependency while keeping the same api, also tries to fix the tests