### PR TITLE
remove object keys, because we can't have nice things

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow)
   module.exports = buffer
 } else {
   // Copy properties from require('buffer')
-  Object.keys(buffer).forEach(function (prop) {
+  for (var prop in buffer) {
     exports[prop] = buffer[prop]
-  })
+  }
   exports.Buffer = SafeBuffer
 }
 

--- a/index.js
+++ b/index.js
@@ -2,13 +2,17 @@
 var buffer = require('buffer')
 var Buffer = buffer.Buffer
 
+// alternative to using Object.keys for old browsers
+function copyProps (src, dst) {
+  for (var key in src) {
+    dst[key] = src[key]
+  }
+}
 if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
   module.exports = buffer
 } else {
   // Copy properties from require('buffer')
-  for (var prop in buffer) {
-    exports[prop] = buffer[prop]
-  }
+  copyProps(buffer, exports)
   exports.Buffer = SafeBuffer
 }
 
@@ -17,9 +21,7 @@ function SafeBuffer (arg, encodingOrOffset, length) {
 }
 
 // Copy static methods from Buffer
-Object.keys(Buffer).forEach(function (prop) {
-  SafeBuffer[prop] = Buffer[prop]
-})
+copyProps(Buffer, SafeBuffer)
 
 SafeBuffer.from = function (arg, encodingOrOffset, length) {
   if (typeof arg === 'number') {


### PR DESCRIPTION
we got an but about readable stream breaking some really old environments due to object keys being present in this lib, nodejs/readable-stream#293