### PR TITLE
Reduced npm package size by excluding tests and CI files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "type": "git",
     "url": "git://github.com/feross/safe-buffer.git"
   },
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "standard && tape test.js"
   }


### PR DESCRIPTION
Files included in package after this change (output from [this tool](https://gist.github.com/anonymous/9d6d38b06d0a88eed4e3b4c648a9f5c1)):

```
package.json
index.js
LICENSE
README.md
```