### PR TITLE
Make SafeBuffer's prototype inherit from Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ function SafeBuffer (arg, encodingOrOffset, length) {
   return Buffer(arg, encodingOrOffset, length)
 }
 
+SafeBuffer.prototype = Object.create(Buffer.prototype)
+
 // Copy static methods from Buffer
 copyProps(Buffer, SafeBuffer)
 


### PR DESCRIPTION
Re: Automattic/mongoose#7102, you get annoying issues if you use SafeBuffer's prototype, like:

```javascript
const Buffer = require('safe-buffer').Buffer;
Buffer.prototype.copy; // undefined on Node.js 4.2
```

This fixes that