### PR TITLE
Add the `buffer` polyfill as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
       "type": "consulting",
       "url": "https://feross.org/support"
     }
-  ]
+  ],
+  "dependencies": {
+    "buffer": "^6.0.3"
+  }
 }


### PR DESCRIPTION
In browser-based environments, require("buffer") will fail unless
`buffer` is available as a dependency and can be provided by a
bundler. This used to automatically be the case in e.g. older
versions of Webpack, but since Webpack v5 no longer automatically
includes polyfills for Node built-ins, it can happen that the
`buffer` polyfill is no longer available in a project's dependency
tree.

Fixes #18 and https://github.com/nodejs/readable-stream/issues/448.