### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -166,7 +166,7 @@ declare module "safe-buffer" {
      * @param size count of octets to allocate.
      * @param fill if specified, buffer will be initialized by calling buf.fill(fill).
      *    If parameter is omitted, buffer will be filled with zeros.
-     * @param encoding encoding used for call to buf.fill while initalizing
+     * @param encoding encoding used for call to buf.fill while initializing
      */
     static alloc(size: number, fill?: string | Buffer | number, encoding?: string): Buffer;
     /**

--- a/test/basic.js
+++ b/test/basic.js
@@ -42,7 +42,7 @@ test('SafeBuffer.alloc(number) returns zeroed-out memory', function (t) {
 })
 
 test('SafeBuffer.allocUnsafe(number)', function (t) {
-  var buf = SafeBuffer.allocUnsafe(100) // unitialized memory
+  var buf = SafeBuffer.allocUnsafe(100) // uninitialized memory
   t.equal(buf.length, 100)
   t.equal(SafeBuffer.isBuffer(buf), true)
   t.equal(Buffer.isBuffer(buf), true)


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell`
```
 ./index.d.ts:169: initalizing ==> initializing
./test/basic.js:45: unitialized ==> uninitialized
```
% `codespell --write-changes` 